### PR TITLE
feat: refactor entities to align with requirements specification

### DIFF
--- a/src/main/java/com/lawgenie/backend_api/entity/ai/AiAnalysisReport.java
+++ b/src/main/java/com/lawgenie/backend_api/entity/ai/AiAnalysisReport.java
@@ -6,38 +6,42 @@ import com.lawgenie.backend_api.entity.product.Product;
 import jakarta.persistence.*;
 import lombok.*;
 
-@Entity
-@Table(name = "ai_analysis_reports")
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+/**
+ * DEPRECATED: 요구명세서에 따라 ProductAnalysisCache로 대체됨
+ * AI 분석 결과는 캐시 시스템을 통해 관리
+ */
+// @Entity
+// @Table(name = "ai_analysis_reports")
+// @Getter
+// @Setter
+// @NoArgsConstructor
+// @AllArgsConstructor
+// @Builder
 public class AiAnalysisReport extends BaseEntity {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  // @Id
+  // @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Integer id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "product_id", nullable = false)
+  // @ManyToOne(fetch = FetchType.LAZY)
+  // @JoinColumn(name = "product_id", nullable = false)
   private Product product;
 
-  @Column(name = "report_type", length = 20)
+  // @Column(name = "report_type", length = 20)
   private String reportType;
 
-  @Lob
-  @Column(name = "analysis_content")
+  // @Lob
+  // @Column(name = "analysis_content")
   private String analysisContent;
 
-  @Lob
-  @Column(name = "ai_reasoning")
+  // @Lob
+  // @Column(name = "ai_reasoning")
   private String aiReasoning;
 
-  @Column(columnDefinition = "json")
+  // @Column(columnDefinition = "json")
   private String metadata;
 
-  @Enumerated(EnumType.STRING)
-  @Column(length = 20)
+  // @Enumerated(EnumType.STRING)
+  // @Column(length = 20)
   private AiReportStatus status;
 }

--- a/src/main/java/com/lawgenie/backend_api/entity/broker/BrokerReview.java
+++ b/src/main/java/com/lawgenie/backend_api/entity/broker/BrokerReview.java
@@ -38,6 +38,9 @@ public class BrokerReview extends BaseEntity {
   @Column(name = "review_comment")
   private String reviewComment;
 
+  @Column(name = "suggested_hs_code", length = 20)
+  private String suggestedHsCode;
+
   @Column(name = "requested_at")
   private LocalDateTime requestedAt;
 

--- a/src/main/java/com/lawgenie/backend_api/entity/cache/AnalysisQueue.java
+++ b/src/main/java/com/lawgenie/backend_api/entity/cache/AnalysisQueue.java
@@ -1,0 +1,56 @@
+package com.lawgenie.backend_api.entity.cache;
+
+import com.lawgenie.backend_api.entity.product.Product;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "analysis_queue")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AnalysisQueue {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "product_id", nullable = false)
+  private Product product;
+
+  @Lob
+  @Column(name = "analysis_types", nullable = false, columnDefinition = "json")
+  private String analysisTypes; // ['tariff_1qty', 'tariff_10qty', 'requirements', 'precedents']
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", length = 20)
+  private QueueStatus status; // pending, processing, completed, failed
+
+  @Column(name = "priority")
+  private Integer priority;
+
+  @Column(name = "scheduled_at")
+  private LocalDateTime scheduledAt;
+
+  @Column(name = "started_at")
+  private LocalDateTime startedAt;
+
+  @Column(name = "completed_at")
+  private LocalDateTime completedAt;
+
+  @Lob
+  @Column(name = "error_message")
+  private String errorMessage;
+
+  @Column(name = "retry_count")
+  private Integer retryCount;
+
+  public enum QueueStatus {
+    PENDING, PROCESSING, COMPLETED, FAILED
+  }
+}

--- a/src/main/java/com/lawgenie/backend_api/entity/cache/ProductAnalysisCache.java
+++ b/src/main/java/com/lawgenie/backend_api/entity/cache/ProductAnalysisCache.java
@@ -1,0 +1,44 @@
+package com.lawgenie.backend_api.entity.cache;
+
+import com.lawgenie.backend_api.entity.base.BaseEntity;
+import com.lawgenie.backend_api.entity.product.Product;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "product_analysis_cache", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"product_id", "analysis_type"}))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductAnalysisCache extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "product_id", nullable = false)
+  private Product product;
+
+  @Column(name = "analysis_type", nullable = false, length = 50)
+  private String analysisType; // 'hs_code', 'tariff_1qty', 'tariff_10qty', 'requirements', 'precedents'
+
+  @Lob
+  @Column(name = "analysis_result", nullable = false, columnDefinition = "json")
+  private String analysisResult;
+
+  @Lob
+  @Column(name = "sources", nullable = false, columnDefinition = "json")
+  private String sources;
+
+  @Column(name = "confidence_score", precision = 3, scale = 2)
+  private BigDecimal confidenceScore;
+
+  @Column(name = "is_valid", nullable = false)
+  private Boolean isValid;
+}

--- a/src/main/java/com/lawgenie/backend_api/entity/chat/ChatSession.java
+++ b/src/main/java/com/lawgenie/backend_api/entity/chat/ChatSession.java
@@ -28,6 +28,9 @@ public class ChatSession extends BaseEntity {
   @Column(name = "session_type", length = 20)
   private ChatSessionType sessionType;
 
+  @Column(name = "language", length = 5, nullable = false)
+  private String language;
+
   @Enumerated(EnumType.STRING)
   @Column(length = 20)
   private ChatSessionStatus status;

--- a/src/main/java/com/lawgenie/backend_api/entity/hs/HsCode.java
+++ b/src/main/java/com/lawgenie/backend_api/entity/hs/HsCode.java
@@ -17,11 +17,11 @@ import java.time.LocalDateTime;
 public class HsCode extends BaseEntity {
 
   @Id
-  @Column(name = "hs_code", length = 15)
+  @Column(name = "hs_code", length = 20)
   private String hsCode;
 
   @Lob
-  @Column(name = "description")
+  @Column(name = "description", nullable = false)
   private String description;
 
   @Column(name = "us_tariff_rate", precision = 5, scale = 4)

--- a/src/main/java/com/lawgenie/backend_api/entity/inquiry/ProductInquiry.java
+++ b/src/main/java/com/lawgenie/backend_api/entity/inquiry/ProductInquiry.java
@@ -38,4 +38,14 @@ public class ProductInquiry extends BaseEntity {
   @Lob
   @Column(name = "ai_response")
   private String aiResponse;
+
+  @Lob
+  @Column(name = "response_sources", columnDefinition = "json")
+  private String responseSources;
+
+  @Column(name = "from_cache", nullable = false)
+  private Boolean fromCache;
+
+  @Column(name = "response_time_ms")
+  private Integer responseTimeMs;
 }

--- a/src/main/java/com/lawgenie/backend_api/entity/product/Product.java
+++ b/src/main/java/com/lawgenie/backend_api/entity/product/Product.java
@@ -26,14 +26,14 @@ public class Product extends BaseEntity {
   @JoinColumn(name = "seller_id", nullable = false)
   private User seller;
 
-  @Column(name = "product_id", nullable = false, unique = true, length = 20)
+  @Column(name = "product_id", nullable = false, unique = true, length = 50)
   private String productId;
 
   @Column(name = "product_name", nullable = false, length = 255)
   private String productName;
 
   @Lob
-  @Column(name = "description")
+  @Column(name = "description", nullable = false)
   private String description;
 
   @Column(precision = 19, scale = 4)
@@ -45,8 +45,8 @@ public class Product extends BaseEntity {
   @Column(name = "origin_country", length = 3)
   private String originCountry;
 
-  @Column(name = "hs_code", length = 15)
-  private String hsCodeValue;
+  @Column(name = "hs_code", length = 20)
+  private String hsCode;
 
   @Enumerated(EnumType.STRING)
   @Column(length = 20)
@@ -57,5 +57,5 @@ public class Product extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "hs_code", referencedColumnName = "hs_code", insertable = false, updatable = false)
-  private HsCode hsCode;
+  private HsCode hsCodeEntity;
 }

--- a/src/main/java/com/lawgenie/backend_api/entity/tariff/TariffCalculation.java
+++ b/src/main/java/com/lawgenie/backend_api/entity/tariff/TariffCalculation.java
@@ -44,6 +44,10 @@ public class TariffCalculation {
   @Column(name = "total_with_tariff", precision = 19, scale = 4)
   private BigDecimal totalWithTariff;
 
+  @Lob
+  @Column(name = "calculation_sources", columnDefinition = "json")
+  private String calculationSources;
+
   @Column(name = "calculated_at", nullable = false)
   private LocalDateTime calculatedAt;
 }

--- a/src/main/java/com/lawgenie/backend_api/entity/tariff/TariffRateHistory.java
+++ b/src/main/java/com/lawgenie/backend_api/entity/tariff/TariffRateHistory.java
@@ -7,35 +7,39 @@ import lombok.*;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
-@Entity
-@Table(name = "tariff_rate_history")
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+/**
+ * DEPRECATED: 요구명세서에 따라 HsCode.us_tariff_rate로 단순화
+ * 관세율은 HsCode 테이블에서 직접 관리
+ */
+// @Entity
+// @Table(name = "tariff_rate_history")
+// @Getter
+// @Setter
+// @NoArgsConstructor
+// @AllArgsConstructor
+// @Builder
 public class TariffRateHistory extends BaseEntity {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  // @Id
+  // @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Integer id;
 
-  @Column(name = "hs_code", length = 15, nullable = false)
+  // @Column(name = "hs_code", length = 15, nullable = false)
   private String hsCode;
 
-  @Column(name = "origin_country", length = 3)
+  // @Column(name = "origin_country", length = 3)
   private String originCountry;
 
-  @Column(name = "tariff_rate", precision = 5, scale = 4)
+  // @Column(name = "tariff_rate", precision = 5, scale = 4)
   private BigDecimal tariffRate;
 
-  @Column(name = "effective_from")
+  // @Column(name = "effective_from")
   private LocalDate effectiveFrom;
 
-  @Column(name = "effective_to")
+  // @Column(name = "effective_to")
   private LocalDate effectiveTo;
 
-  @Lob
-  @Column(name = "change_reason")
+  // @Lob
+  // @Column(name = "change_reason")
   private String changeReason;
 }

--- a/src/main/java/com/lawgenie/backend_api/entity/user/User.java
+++ b/src/main/java/com/lawgenie/backend_api/entity/user/User.java
@@ -31,6 +31,9 @@ public class User extends BaseEntity {
   @Column(name = "user_name", length = 100)
   private String userName;
 
+  @Column(name = "preferred_language", length = 5)
+  private String preferredLanguage;
+
   @Column(name = "is_active", nullable = false)
   private Boolean isActive;
 }


### PR DESCRIPTION
- Add preferred_language field to User entity for multilingual support
- Add ProductAnalysisCache entity for AI analysis result caching
- Add AnalysisQueue entity for background analysis task management
- Add language field to ChatSession for multilingual chat support
- Add calculation_sources field to TariffCalculation for source tracking
- Add cache-related fields to ProductInquiry (from_cache, response_time_ms)
- Add suggested_hs_code field to BrokerReview for broker recommendations
- Deprecate AiAnalysisReport entity (replaced by ProductAnalysisCache)
- Deprecate TariffRateHistory entity (simplified to HsCode.us_tariff_rate)