### PR TITLE
feat: 관세사 상품 리뷰 API 구현 from feature/broker-api

### DIFF
--- a/src/main/java/com/suracle/backend_api/controller/BrokerReviewController.java
+++ b/src/main/java/com/suracle/backend_api/controller/BrokerReviewController.java
@@ -1,0 +1,240 @@
+package com.suracle.backend_api.controller;
+
+import com.suracle.backend_api.dto.broker.BrokerReviewListResponseDto;
+import com.suracle.backend_api.dto.broker.BrokerReviewRequestDto;
+import com.suracle.backend_api.dto.broker.BrokerReviewResponseDto;
+import com.suracle.backend_api.entity.broker.enums.ReviewStatus;
+import com.suracle.backend_api.service.BrokerReviewService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/broker/reviews")
+@RequiredArgsConstructor
+@Slf4j
+public class BrokerReviewController {
+
+    private final BrokerReviewService brokerReviewService;
+
+    /**
+     * 리뷰 요청 생성
+     * @param requestDto 리뷰 요청 정보
+     * @return 생성된 리뷰 정보
+     */
+    @PostMapping
+    public ResponseEntity<BrokerReviewResponseDto> createReviewRequest(
+            @Valid @RequestBody BrokerReviewRequestDto requestDto) {
+        try {
+            log.info("리뷰 요청 생성 API 호출 - 상품 ID: {}, 관세사 ID: {}", 
+                    requestDto.getProductId(), requestDto.getBrokerId());
+            
+            BrokerReviewResponseDto response = brokerReviewService.createReviewRequest(requestDto);
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("리뷰 요청 생성 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        } catch (Exception e) {
+            log.error("리뷰 요청 생성 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 리뷰 상태 업데이트 (관세사가 리뷰 처리)
+     * @param reviewId 리뷰 ID
+     * @param reviewStatus 새로운 리뷰 상태
+     * @param reviewComment 리뷰 코멘트
+     * @param suggestedHsCode 제안된 HS코드
+     * @return 업데이트된 리뷰 정보
+     */
+    @PutMapping("/{reviewId}")
+    public ResponseEntity<BrokerReviewResponseDto> updateReviewStatus(
+            @PathVariable Integer reviewId,
+            @RequestParam ReviewStatus reviewStatus,
+            @RequestParam(required = false) String reviewComment,
+            @RequestParam(required = false) String suggestedHsCode) {
+        try {
+            log.info("리뷰 상태 업데이트 API 호출 - 리뷰 ID: {}, 상태: {}", reviewId, reviewStatus);
+            
+            BrokerReviewResponseDto response = brokerReviewService.updateReviewStatus(
+                    reviewId, reviewStatus, reviewComment, suggestedHsCode);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("리뷰 상태 업데이트 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        } catch (Exception e) {
+            log.error("리뷰 상태 업데이트 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 리뷰 상세 조회
+     * @param reviewId 리뷰 ID
+     * @return 리뷰 상세 정보
+     */
+    @GetMapping("/{reviewId}")
+    public ResponseEntity<BrokerReviewResponseDto> getReviewById(@PathVariable Integer reviewId) {
+        try {
+            log.info("리뷰 상세 조회 API 호출 - 리뷰 ID: {}", reviewId);
+            
+            BrokerReviewResponseDto response = brokerReviewService.getReviewById(reviewId);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("리뷰 조회 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        } catch (Exception e) {
+            log.error("리뷰 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 관세사별 리뷰 목록 조회
+     * @param brokerId 관세사 ID
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 10)
+     * @return 관세사 리뷰 목록
+     */
+    @GetMapping("/broker/{brokerId}")
+    public ResponseEntity<Page<BrokerReviewListResponseDto>> getReviewsByBrokerId(
+            @PathVariable Integer brokerId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        try {
+            log.info("관세사별 리뷰 목록 조회 API 호출 - 관세사 ID: {}, 페이지: {}", brokerId, page);
+            
+            Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+            Page<BrokerReviewListResponseDto> response = brokerReviewService.getReviewsByBrokerId(brokerId, pageable);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("관세사별 리뷰 목록 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 상품별 리뷰 목록 조회
+     * @param productId 상품 ID
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 10)
+     * @return 상품 리뷰 목록
+     */
+    @GetMapping("/product/{productId}")
+    public ResponseEntity<Page<BrokerReviewListResponseDto>> getReviewsByProductId(
+            @PathVariable Integer productId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        try {
+            log.info("상품별 리뷰 목록 조회 API 호출 - 상품 ID: {}, 페이지: {}", productId, page);
+            
+            Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+            Page<BrokerReviewListResponseDto> response = brokerReviewService.getReviewsByProductId(productId, pageable);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("상품별 리뷰 목록 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 리뷰 상태별 목록 조회
+     * @param status 리뷰 상태
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 10)
+     * @return 리뷰 목록
+     */
+    @GetMapping("/status/{status}")
+    public ResponseEntity<Page<BrokerReviewListResponseDto>> getReviewsByStatus(
+            @PathVariable ReviewStatus status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        try {
+            log.info("리뷰 상태별 목록 조회 API 호출 - 상태: {}, 페이지: {}", status, page);
+            
+            Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+            Page<BrokerReviewListResponseDto> response = brokerReviewService.getReviewsByStatus(status, pageable);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("리뷰 상태별 목록 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 관세사별 대기 중인 리뷰 목록 조회
+     * @param brokerId 관세사 ID
+     * @return 대기 중인 리뷰 목록
+     */
+    @GetMapping("/broker/{brokerId}/pending")
+    public ResponseEntity<List<BrokerReviewListResponseDto>> getPendingReviewsByBrokerId(
+            @PathVariable Integer brokerId) {
+        try {
+            log.info("관세사별 대기 중인 리뷰 목록 조회 API 호출 - 관세사 ID: {}", brokerId);
+            
+            List<BrokerReviewListResponseDto> response = brokerReviewService.getPendingReviewsByBrokerId(brokerId);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("관세사별 대기 중인 리뷰 목록 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 상품별 최신 리뷰 조회
+     * @param productId 상품 ID
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 10)
+     * @return 최신 리뷰 목록
+     */
+    @GetMapping("/product/{productId}/latest")
+    public ResponseEntity<Page<BrokerReviewListResponseDto>> getLatestReviewsByProductId(
+            @PathVariable Integer productId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        try {
+            log.info("상품별 최신 리뷰 조회 API 호출 - 상품 ID: {}, 페이지: {}", productId, page);
+            
+            Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+            Page<BrokerReviewListResponseDto> response = brokerReviewService.getLatestReviewsByProductId(productId, pageable);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("상품별 최신 리뷰 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 리뷰 삭제
+     * @param reviewId 리뷰 ID
+     * @param brokerId 관세사 ID (헤더로 전달)
+     * @return 삭제 결과
+     */
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<Void> deleteReview(
+            @PathVariable Integer reviewId,
+            @RequestHeader("X-Broker-Id") Integer brokerId) {
+        try {
+            log.info("리뷰 삭제 API 호출 - 리뷰 ID: {}, 관세사 ID: {}", reviewId, brokerId);
+            
+            brokerReviewService.deleteReview(reviewId, brokerId);
+            return ResponseEntity.noContent().build();
+        } catch (IllegalArgumentException e) {
+            log.warn("리뷰 삭제 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        } catch (Exception e) {
+            log.error("리뷰 삭제 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/src/main/java/com/suracle/backend_api/controller/ProductController.java
+++ b/src/main/java/com/suracle/backend_api/controller/ProductController.java
@@ -5,6 +5,9 @@ import com.suracle.backend_api.dto.product.ProductRequestDto;
 import com.suracle.backend_api.dto.precedents.PrecedentsResponseDto;
 import com.suracle.backend_api.dto.product.ProductResponseDto;
 import com.suracle.backend_api.service.ProductService;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -190,6 +193,31 @@ public class ProductController {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         } catch (Exception e) {
             log.error("판례 분석 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 상품 ID 매핑 조회 (숫자 ID -> 문자열 productId)
+     * @param id 숫자 ID
+     * @return ID 매핑 정보
+     */
+    @GetMapping("/id-mapping/{id}")
+    public ResponseEntity<Map<String, String>> getProductIdMapping(@PathVariable Integer id) {
+        try {
+            log.info("상품 ID 매핑 조회 요청 - ID: {}", id);
+            Optional<ProductResponseDto> product = productService.getProductById(id);
+            if (product.isPresent()) {
+                Map<String, String> mapping = new HashMap<>();
+                mapping.put("id", id.toString());
+                mapping.put("productId", product.get().getProductId());
+                mapping.put("productName", product.get().getProductName());
+                return ResponseEntity.ok(mapping);
+            } else {
+                return ResponseEntity.notFound().build();
+            }
+        } catch (Exception e) {
+            log.error("상품 ID 매핑 조회 중 오류 발생", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }

--- a/src/main/java/com/suracle/backend_api/controller/ProductInquiryController.java
+++ b/src/main/java/com/suracle/backend_api/controller/ProductInquiryController.java
@@ -1,0 +1,235 @@
+package com.suracle.backend_api.controller;
+
+import com.suracle.backend_api.dto.inquiry.ProductInquiryRequestDto;
+import com.suracle.backend_api.dto.inquiry.ProductInquiryResponseDto;
+import com.suracle.backend_api.entity.inquiry.enums.InquiryType;
+import com.suracle.backend_api.service.ProductInquiryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/inquiries")
+@RequiredArgsConstructor
+@Slf4j
+public class ProductInquiryController {
+
+    private final ProductInquiryService productInquiryService;
+
+    /**
+     * 문의 생성
+     * @param requestDto 문의 요청 정보
+     * @return 생성된 문의 정보
+     */
+    @PostMapping
+    public ResponseEntity<ProductInquiryResponseDto> createInquiry(
+            @Valid @RequestBody ProductInquiryRequestDto requestDto) {
+        try {
+            log.info("문의 생성 API 호출 - 사용자 ID: {}, 상품 ID: {}", 
+                    requestDto.getUserId(), requestDto.getProductId());
+            
+            ProductInquiryResponseDto response = productInquiryService.createInquiry(requestDto);
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("문의 생성 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        } catch (Exception e) {
+            log.error("문의 생성 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 문의 상세 조회
+     * @param inquiryId 문의 ID
+     * @return 문의 상세 정보
+     */
+    @GetMapping("/{inquiryId}")
+    public ResponseEntity<ProductInquiryResponseDto> getInquiryById(@PathVariable Integer inquiryId) {
+        try {
+            log.info("문의 상세 조회 API 호출 - 문의 ID: {}", inquiryId);
+            
+            ProductInquiryResponseDto response = productInquiryService.getInquiryById(inquiryId);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("문의 조회 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        } catch (Exception e) {
+            log.error("문의 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 사용자별 문의 목록 조회
+     * @param userId 사용자 ID
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 10)
+     * @return 사용자 문의 목록
+     */
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<Page<ProductInquiryResponseDto>> getInquiriesByUserId(
+            @PathVariable Integer userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        try {
+            log.info("사용자별 문의 목록 조회 API 호출 - 사용자 ID: {}, 페이지: {}", userId, page);
+            
+            Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+            Page<ProductInquiryResponseDto> response = productInquiryService.getInquiriesByUserId(userId, pageable);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("사용자별 문의 목록 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 상품별 문의 목록 조회
+     * @param productId 상품 ID
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 10)
+     * @return 상품 문의 목록
+     */
+    @GetMapping("/product/{productId}")
+    public ResponseEntity<Page<ProductInquiryResponseDto>> getInquiriesByProductId(
+            @PathVariable Integer productId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        try {
+            log.info("상품별 문의 목록 조회 API 호출 - 상품 ID: {}, 페이지: {}", productId, page);
+            
+            Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+            Page<ProductInquiryResponseDto> response = productInquiryService.getInquiriesByProductId(productId, pageable);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("상품별 문의 목록 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 문의 유형별 목록 조회
+     * @param inquiryType 문의 유형
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 10)
+     * @return 문의 목록
+     */
+    @GetMapping("/type/{inquiryType}")
+    public ResponseEntity<Page<ProductInquiryResponseDto>> getInquiriesByType(
+            @PathVariable InquiryType inquiryType,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        try {
+            log.info("문의 유형별 목록 조회 API 호출 - 문의 유형: {}, 페이지: {}", inquiryType, page);
+            
+            Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+            Page<ProductInquiryResponseDto> response = productInquiryService.getInquiriesByType(inquiryType, pageable);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("문의 유형별 목록 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 사용자별 문의 유형별 조회
+     * @param userId 사용자 ID
+     * @param inquiryType 문의 유형
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 10)
+     * @return 문의 목록
+     */
+    @GetMapping("/user/{userId}/type/{inquiryType}")
+    public ResponseEntity<Page<ProductInquiryResponseDto>> getInquiriesByUserIdAndType(
+            @PathVariable Integer userId,
+            @PathVariable InquiryType inquiryType,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        try {
+            log.info("사용자별 문의 유형별 조회 API 호출 - 사용자 ID: {}, 문의 유형: {}, 페이지: {}", userId, inquiryType, page);
+            
+            Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+            Page<ProductInquiryResponseDto> response = productInquiryService.getInquiriesByUserIdAndType(userId, inquiryType, pageable);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("사용자별 문의 유형별 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 최근 문의 조회
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 10)
+     * @return 최근 문의 목록
+     */
+    @GetMapping("/recent")
+    public ResponseEntity<Page<ProductInquiryResponseDto>> getRecentInquiries(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        try {
+            log.info("최근 문의 조회 API 호출 - 페이지: {}", page);
+            
+            Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+            Page<ProductInquiryResponseDto> response = productInquiryService.getRecentInquiries(pageable);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("최근 문의 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * AI 응답이 있는 문의 조회
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 10)
+     * @return AI 응답 문의 목록
+     */
+    @GetMapping("/ai-responses")
+    public ResponseEntity<Page<ProductInquiryResponseDto>> getInquiriesWithAiResponse(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        try {
+            log.info("AI 응답이 있는 문의 조회 API 호출 - 페이지: {}", page);
+            
+            Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+            Page<ProductInquiryResponseDto> response = productInquiryService.getInquiriesWithAiResponse(pageable);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("AI 응답이 있는 문의 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 문의 삭제
+     * @param inquiryId 문의 ID
+     * @param userId 사용자 ID (헤더로 전달)
+     * @return 삭제 결과
+     */
+    @DeleteMapping("/{inquiryId}")
+    public ResponseEntity<Void> deleteInquiry(
+            @PathVariable Integer inquiryId,
+            @RequestHeader("X-User-Id") Integer userId) {
+        try {
+            log.info("문의 삭제 API 호출 - 문의 ID: {}, 사용자 ID: {}", inquiryId, userId);
+            
+            productInquiryService.deleteInquiry(inquiryId, userId);
+            return ResponseEntity.noContent().build();
+        } catch (IllegalArgumentException e) {
+            log.warn("문의 삭제 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        } catch (Exception e) {
+            log.error("문의 삭제 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/src/main/java/com/suracle/backend_api/dto/broker/BrokerReviewListResponseDto.java
+++ b/src/main/java/com/suracle/backend_api/dto/broker/BrokerReviewListResponseDto.java
@@ -1,0 +1,27 @@
+package com.suracle.backend_api.dto.broker;
+
+import com.suracle.backend_api.entity.broker.enums.ReviewStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BrokerReviewListResponseDto {
+
+    private Integer id;
+    private Integer productId;
+    private String productName;
+    private Integer brokerId;
+    private String brokerName;
+    private ReviewStatus reviewStatus;
+    private String reviewComment;
+    private LocalDateTime requestedAt;
+    private LocalDateTime reviewedAt;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/suracle/backend_api/dto/broker/BrokerReviewRequestDto.java
+++ b/src/main/java/com/suracle/backend_api/dto/broker/BrokerReviewRequestDto.java
@@ -1,0 +1,32 @@
+package com.suracle.backend_api.dto.broker;
+
+import com.suracle.backend_api.entity.broker.enums.ReviewStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BrokerReviewRequestDto {
+
+    @NotNull(message = "상품 ID는 필수입니다")
+    private Integer productId;
+
+    @NotNull(message = "관세사 ID는 필수입니다")
+    private Integer brokerId;
+
+    @NotNull(message = "리뷰 상태는 필수입니다")
+    private ReviewStatus reviewStatus;
+
+    @Size(max = 1000, message = "리뷰 코멘트는 1000자를 초과할 수 없습니다")
+    private String reviewComment;
+
+    @Size(max = 20, message = "제안된 HS코드는 20자를 초과할 수 없습니다")
+    private String suggestedHsCode;
+}

--- a/src/main/java/com/suracle/backend_api/dto/broker/BrokerReviewResponseDto.java
+++ b/src/main/java/com/suracle/backend_api/dto/broker/BrokerReviewResponseDto.java
@@ -1,0 +1,29 @@
+package com.suracle.backend_api.dto.broker;
+
+import com.suracle.backend_api.entity.broker.enums.ReviewStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BrokerReviewResponseDto {
+
+    private Integer id;
+    private Integer productId;
+    private String productName;
+    private Integer brokerId;
+    private String brokerName;
+    private ReviewStatus reviewStatus;
+    private String reviewComment;
+    private String suggestedHsCode;
+    private LocalDateTime requestedAt;
+    private LocalDateTime reviewedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/suracle/backend_api/dto/inquiry/ProductInquiryRequestDto.java
+++ b/src/main/java/com/suracle/backend_api/dto/inquiry/ProductInquiryRequestDto.java
@@ -1,0 +1,34 @@
+package com.suracle.backend_api.dto.inquiry;
+
+import com.suracle.backend_api.entity.inquiry.enums.InquiryType;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductInquiryRequestDto {
+
+    @NotNull(message = "사용자 ID는 필수입니다")
+    private Integer userId;
+
+    private Integer productId;
+
+    @NotNull(message = "문의 유형은 필수입니다")
+    private InquiryType inquiryType;
+
+    private String inquiryData;
+
+    private String aiResponse;
+
+    private String responseSources;
+
+    @Builder.Default
+    private Boolean fromCache = false;
+
+    private Integer responseTimeMs;
+}

--- a/src/main/java/com/suracle/backend_api/dto/inquiry/ProductInquiryResponseDto.java
+++ b/src/main/java/com/suracle/backend_api/dto/inquiry/ProductInquiryResponseDto.java
@@ -1,0 +1,30 @@
+package com.suracle.backend_api.dto.inquiry;
+
+import com.suracle.backend_api.entity.inquiry.enums.InquiryType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductInquiryResponseDto {
+
+    private Integer id;
+    private Integer userId;
+    private String userName;
+    private Integer productId;
+    private String productName;
+    private InquiryType inquiryType;
+    private String inquiryData;
+    private String aiResponse;
+    private String responseSources;
+    private Boolean fromCache;
+    private Integer responseTimeMs;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/suracle/backend_api/repository/BrokerReviewRepository.java
+++ b/src/main/java/com/suracle/backend_api/repository/BrokerReviewRepository.java
@@ -1,0 +1,70 @@
+package com.suracle.backend_api.repository;
+
+import com.suracle.backend_api.entity.broker.BrokerReview;
+import com.suracle.backend_api.entity.broker.enums.ReviewStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface BrokerReviewRepository extends JpaRepository<BrokerReview, Integer> {
+
+    /**
+     * 관세사별 리뷰 목록 조회
+     */
+    Page<BrokerReview> findByBrokerIdOrderByCreatedAtDesc(Integer brokerId, Pageable pageable);
+
+    /**
+     * 상품별 리뷰 목록 조회
+     */
+    Page<BrokerReview> findByProductIdOrderByCreatedAtDesc(Integer productId, Pageable pageable);
+
+    /**
+     * 리뷰 상태별 조회
+     */
+    Page<BrokerReview> findByReviewStatusOrderByCreatedAtDesc(ReviewStatus reviewStatus, Pageable pageable);
+
+    /**
+     * 관세사별 리뷰 상태별 조회
+     */
+    Page<BrokerReview> findByBrokerIdAndReviewStatusOrderByCreatedAtDesc(
+            Integer brokerId, ReviewStatus reviewStatus, Pageable pageable);
+
+    /**
+     * 상품과 관세사로 리뷰 조회
+     */
+    Optional<BrokerReview> findByProductIdAndBrokerId(Integer productId, Integer brokerId);
+
+    /**
+     * 상품별 리뷰 개수 조회
+     */
+    long countByProductId(Integer productId);
+
+    /**
+     * 관세사별 리뷰 개수 조회
+     */
+    long countByBrokerId(Integer brokerId);
+
+    /**
+     * 리뷰 상태별 리뷰 개수 조회
+     */
+    long countByReviewStatus(ReviewStatus reviewStatus);
+
+    /**
+     * 대기 중인 리뷰 목록 조회 (관세사별)
+     */
+    @Query("SELECT br FROM BrokerReview br WHERE br.broker.id = :brokerId ORDER BY br.requestedAt ASC")
+    List<BrokerReview> findPendingReviewsByBrokerId(@Param("brokerId") Integer brokerId);
+
+    /**
+     * 상품별 최신 리뷰 조회
+     */
+    @Query("SELECT br FROM BrokerReview br WHERE br.product.id = :productId ORDER BY br.createdAt DESC")
+    Page<BrokerReview> findLatestReviewsByProductId(@Param("productId") Integer productId, Pageable pageable);
+}

--- a/src/main/java/com/suracle/backend_api/repository/ProductInquiryRepository.java
+++ b/src/main/java/com/suracle/backend_api/repository/ProductInquiryRepository.java
@@ -1,0 +1,69 @@
+package com.suracle.backend_api.repository;
+
+import com.suracle.backend_api.entity.inquiry.ProductInquiry;
+import com.suracle.backend_api.entity.inquiry.enums.InquiryType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ProductInquiryRepository extends JpaRepository<ProductInquiry, Integer> {
+
+    /**
+     * 사용자별 문의 목록 조회
+     */
+    Page<ProductInquiry> findByUserIdOrderByCreatedAtDesc(Integer userId, Pageable pageable);
+
+    /**
+     * 상품별 문의 목록 조회
+     */
+    Page<ProductInquiry> findByProductIdOrderByCreatedAtDesc(Integer productId, Pageable pageable);
+
+    /**
+     * 문의 유형별 조회
+     */
+    Page<ProductInquiry> findByInquiryTypeOrderByCreatedAtDesc(InquiryType inquiryType, Pageable pageable);
+
+    /**
+     * 사용자별 문의 유형별 조회
+     */
+    Page<ProductInquiry> findByUserIdAndInquiryTypeOrderByCreatedAtDesc(
+            Integer userId, InquiryType inquiryType, Pageable pageable);
+
+    /**
+     * 캐시에서 온 문의 조회
+     */
+    Page<ProductInquiry> findByFromCacheTrueOrderByCreatedAtDesc(Pageable pageable);
+
+    /**
+     * 사용자별 문의 개수 조회
+     */
+    long countByUserId(Integer userId);
+
+    /**
+     * 상품별 문의 개수 조회
+     */
+    long countByProductId(Integer productId);
+
+    /**
+     * 문의 유형별 문의 개수 조회
+     */
+    long countByInquiryType(InquiryType inquiryType);
+
+    /**
+     * 최근 문의 조회 (시간순)
+     */
+    @Query("SELECT pi FROM ProductInquiry pi ORDER BY pi.createdAt DESC")
+    Page<ProductInquiry> findRecentInquiries(Pageable pageable);
+
+    /**
+     * AI 응답이 있는 문의 조회
+     */
+    @Query("SELECT pi FROM ProductInquiry pi WHERE pi.aiResponse IS NOT NULL ORDER BY pi.createdAt DESC")
+    Page<ProductInquiry> findInquiriesWithAiResponse(Pageable pageable);
+}

--- a/src/main/java/com/suracle/backend_api/service/BrokerReviewService.java
+++ b/src/main/java/com/suracle/backend_api/service/BrokerReviewService.java
@@ -1,0 +1,84 @@
+package com.suracle.backend_api.service;
+
+import com.suracle.backend_api.dto.broker.BrokerReviewListResponseDto;
+import com.suracle.backend_api.dto.broker.BrokerReviewRequestDto;
+import com.suracle.backend_api.dto.broker.BrokerReviewResponseDto;
+import com.suracle.backend_api.entity.broker.enums.ReviewStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface BrokerReviewService {
+
+    /**
+     * 리뷰 요청 생성
+     * @param requestDto 리뷰 요청 정보
+     * @return 생성된 리뷰 정보
+     */
+    BrokerReviewResponseDto createReviewRequest(BrokerReviewRequestDto requestDto);
+
+    /**
+     * 리뷰 상태 업데이트 (관세사가 리뷰 처리)
+     * @param reviewId 리뷰 ID
+     * @param reviewStatus 새로운 리뷰 상태
+     * @param reviewComment 리뷰 코멘트
+     * @param suggestedHsCode 제안된 HS코드
+     * @return 업데이트된 리뷰 정보
+     */
+    BrokerReviewResponseDto updateReviewStatus(Integer reviewId, ReviewStatus reviewStatus, 
+                                               String reviewComment, String suggestedHsCode);
+
+    /**
+     * 리뷰 상세 조회
+     * @param reviewId 리뷰 ID
+     * @return 리뷰 상세 정보
+     */
+    BrokerReviewResponseDto getReviewById(Integer reviewId);
+
+    /**
+     * 관세사별 리뷰 목록 조회
+     * @param brokerId 관세사 ID
+     * @param pageable 페이징 정보
+     * @return 관세사 리뷰 목록
+     */
+    Page<BrokerReviewListResponseDto> getReviewsByBrokerId(Integer brokerId, Pageable pageable);
+
+    /**
+     * 상품별 리뷰 목록 조회
+     * @param productId 상품 ID
+     * @param pageable 페이징 정보
+     * @return 상품 리뷰 목록
+     */
+    Page<BrokerReviewListResponseDto> getReviewsByProductId(Integer productId, Pageable pageable);
+
+    /**
+     * 리뷰 상태별 목록 조회
+     * @param reviewStatus 리뷰 상태
+     * @param pageable 페이징 정보
+     * @return 리뷰 목록
+     */
+    Page<BrokerReviewListResponseDto> getReviewsByStatus(ReviewStatus reviewStatus, Pageable pageable);
+
+    /**
+     * 관세사별 대기 중인 리뷰 목록 조회
+     * @param brokerId 관세사 ID
+     * @return 대기 중인 리뷰 목록
+     */
+    List<BrokerReviewListResponseDto> getPendingReviewsByBrokerId(Integer brokerId);
+
+    /**
+     * 상품별 최신 리뷰 조회
+     * @param productId 상품 ID
+     * @param pageable 페이징 정보
+     * @return 최신 리뷰 목록
+     */
+    Page<BrokerReviewListResponseDto> getLatestReviewsByProductId(Integer productId, Pageable pageable);
+
+    /**
+     * 리뷰 삭제
+     * @param reviewId 리뷰 ID
+     * @param brokerId 관세사 ID (권한 확인용)
+     */
+    void deleteReview(Integer reviewId, Integer brokerId);
+}

--- a/src/main/java/com/suracle/backend_api/service/ProductInquiryService.java
+++ b/src/main/java/com/suracle/backend_api/service/ProductInquiryService.java
@@ -1,0 +1,80 @@
+package com.suracle.backend_api.service;
+
+import com.suracle.backend_api.dto.inquiry.ProductInquiryRequestDto;
+import com.suracle.backend_api.dto.inquiry.ProductInquiryResponseDto;
+import com.suracle.backend_api.entity.inquiry.enums.InquiryType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface ProductInquiryService {
+
+    /**
+     * 문의 생성
+     * @param requestDto 문의 요청 정보
+     * @return 생성된 문의 정보
+     */
+    ProductInquiryResponseDto createInquiry(ProductInquiryRequestDto requestDto);
+
+    /**
+     * 문의 상세 조회
+     * @param inquiryId 문의 ID
+     * @return 문의 상세 정보
+     */
+    ProductInquiryResponseDto getInquiryById(Integer inquiryId);
+
+    /**
+     * 사용자별 문의 목록 조회
+     * @param userId 사용자 ID
+     * @param pageable 페이징 정보
+     * @return 사용자 문의 목록
+     */
+    Page<ProductInquiryResponseDto> getInquiriesByUserId(Integer userId, Pageable pageable);
+
+    /**
+     * 상품별 문의 목록 조회
+     * @param productId 상품 ID
+     * @param pageable 페이징 정보
+     * @return 상품 문의 목록
+     */
+    Page<ProductInquiryResponseDto> getInquiriesByProductId(Integer productId, Pageable pageable);
+
+    /**
+     * 문의 유형별 목록 조회
+     * @param inquiryType 문의 유형
+     * @param pageable 페이징 정보
+     * @return 문의 목록
+     */
+    Page<ProductInquiryResponseDto> getInquiriesByType(InquiryType inquiryType, Pageable pageable);
+
+    /**
+     * 사용자별 문의 유형별 조회
+     * @param userId 사용자 ID
+     * @param inquiryType 문의 유형
+     * @param pageable 페이징 정보
+     * @return 문의 목록
+     */
+    Page<ProductInquiryResponseDto> getInquiriesByUserIdAndType(Integer userId, InquiryType inquiryType, Pageable pageable);
+
+    /**
+     * 최근 문의 조회
+     * @param pageable 페이징 정보
+     * @return 최근 문의 목록
+     */
+    Page<ProductInquiryResponseDto> getRecentInquiries(Pageable pageable);
+
+    /**
+     * AI 응답이 있는 문의 조회
+     * @param pageable 페이징 정보
+     * @return AI 응답 문의 목록
+     */
+    Page<ProductInquiryResponseDto> getInquiriesWithAiResponse(Pageable pageable);
+
+    /**
+     * 문의 삭제
+     * @param inquiryId 문의 ID
+     * @param userId 사용자 ID (권한 확인용)
+     */
+    void deleteInquiry(Integer inquiryId, Integer userId);
+}

--- a/src/main/java/com/suracle/backend_api/service/ProductService.java
+++ b/src/main/java/com/suracle/backend_api/service/ProductService.java
@@ -6,6 +6,7 @@ import com.suracle.backend_api.dto.precedents.PrecedentsResponseDto;
 import com.suracle.backend_api.dto.product.ProductResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import java.util.Optional;
 
 public interface ProductService {
 
@@ -30,6 +31,13 @@ public interface ProductService {
      * @return 상품 상세 정보
      */
     ProductResponseDto getProductById(String productId);
+
+    /**
+     * 상품 상세 조회 (숫자 ID)
+     * @param id 숫자 ID
+     * @return 상품 상세 정보
+     */
+    Optional<ProductResponseDto> getProductById(Integer id);
 
     /**
      * 상품 삭제

--- a/src/main/java/com/suracle/backend_api/service/impl/BrokerReviewServiceImpl.java
+++ b/src/main/java/com/suracle/backend_api/service/impl/BrokerReviewServiceImpl.java
@@ -1,0 +1,198 @@
+package com.suracle.backend_api.service.impl;
+
+import com.suracle.backend_api.dto.broker.BrokerReviewListResponseDto;
+import com.suracle.backend_api.dto.broker.BrokerReviewRequestDto;
+import com.suracle.backend_api.dto.broker.BrokerReviewResponseDto;
+import com.suracle.backend_api.entity.broker.BrokerReview;
+import com.suracle.backend_api.entity.broker.enums.ReviewStatus;
+import com.suracle.backend_api.entity.product.Product;
+import com.suracle.backend_api.entity.user.User;
+import com.suracle.backend_api.repository.BrokerReviewRepository;
+import com.suracle.backend_api.repository.ProductRepository;
+import com.suracle.backend_api.repository.UserRepository;
+import com.suracle.backend_api.service.BrokerReviewService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class BrokerReviewServiceImpl implements BrokerReviewService {
+
+    private final BrokerReviewRepository brokerReviewRepository;
+    private final ProductRepository productRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public BrokerReviewResponseDto createReviewRequest(BrokerReviewRequestDto requestDto) {
+        log.info("리뷰 요청 생성 - 상품 ID: {}, 관세사 ID: {}", requestDto.getProductId(), requestDto.getBrokerId());
+
+        // 상품 존재 확인
+        Product product = productRepository.findById(requestDto.getProductId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다: " + requestDto.getProductId()));
+
+        // 관세사 존재 확인
+        User broker = userRepository.findById(requestDto.getBrokerId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 관세사입니다: " + requestDto.getBrokerId()));
+
+        // 기존 리뷰 확인
+        if (brokerReviewRepository.findByProductIdAndBrokerId(requestDto.getProductId(), requestDto.getBrokerId()).isPresent()) {
+            throw new IllegalArgumentException("이미 해당 상품에 대한 리뷰가 존재합니다");
+        }
+
+        // 리뷰 생성
+        BrokerReview review = BrokerReview.builder()
+                .product(product)
+                .broker(broker)
+                .reviewStatus(requestDto.getReviewStatus())
+                .reviewComment(requestDto.getReviewComment())
+                .suggestedHsCode(requestDto.getSuggestedHsCode())
+                .requestedAt(LocalDateTime.now())
+                .build();
+
+        BrokerReview savedReview = brokerReviewRepository.save(review);
+        log.info("리뷰 요청 생성 완료 - 리뷰 ID: {}", savedReview.getId());
+
+        return convertToResponseDto(savedReview);
+    }
+
+    @Override
+    public BrokerReviewResponseDto updateReviewStatus(Integer reviewId, ReviewStatus reviewStatus, 
+                                                      String reviewComment, String suggestedHsCode) {
+        log.info("리뷰 상태 업데이트 - 리뷰 ID: {}, 상태: {}", reviewId, reviewStatus);
+
+        BrokerReview review = brokerReviewRepository.findById(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리뷰입니다: " + reviewId));
+
+        review.setReviewStatus(reviewStatus);
+        review.setReviewComment(reviewComment);
+        review.setSuggestedHsCode(suggestedHsCode);
+        review.setReviewedAt(LocalDateTime.now());
+
+        BrokerReview savedReview = brokerReviewRepository.save(review);
+        log.info("리뷰 상태 업데이트 완료 - 리뷰 ID: {}", savedReview.getId());
+
+        return convertToResponseDto(savedReview);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public BrokerReviewResponseDto getReviewById(Integer reviewId) {
+        log.info("리뷰 상세 조회 - 리뷰 ID: {}", reviewId);
+
+        BrokerReview review = brokerReviewRepository.findById(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리뷰입니다: " + reviewId));
+
+        return convertToResponseDto(review);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<BrokerReviewListResponseDto> getReviewsByBrokerId(Integer brokerId, Pageable pageable) {
+        log.info("관세사별 리뷰 목록 조회 - 관세사 ID: {}", brokerId);
+
+        Page<BrokerReview> reviews = brokerReviewRepository.findByBrokerIdOrderByCreatedAtDesc(brokerId, pageable);
+        return reviews.map(this::convertToListResponseDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<BrokerReviewListResponseDto> getReviewsByProductId(Integer productId, Pageable pageable) {
+        log.info("상품별 리뷰 목록 조회 - 상품 ID: {}", productId);
+
+        Page<BrokerReview> reviews = brokerReviewRepository.findByProductIdOrderByCreatedAtDesc(productId, pageable);
+        return reviews.map(this::convertToListResponseDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<BrokerReviewListResponseDto> getReviewsByStatus(ReviewStatus reviewStatus, Pageable pageable) {
+        log.info("리뷰 상태별 목록 조회 - 상태: {}", reviewStatus);
+
+        Page<BrokerReview> reviews = brokerReviewRepository.findByReviewStatusOrderByCreatedAtDesc(reviewStatus, pageable);
+        return reviews.map(this::convertToListResponseDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<BrokerReviewListResponseDto> getPendingReviewsByBrokerId(Integer brokerId) {
+        log.info("관세사별 대기 중인 리뷰 목록 조회 - 관세사 ID: {}", brokerId);
+
+        List<BrokerReview> reviews = brokerReviewRepository.findPendingReviewsByBrokerId(brokerId);
+        return reviews.stream()
+                .map(this::convertToListResponseDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<BrokerReviewListResponseDto> getLatestReviewsByProductId(Integer productId, Pageable pageable) {
+        log.info("상품별 최신 리뷰 조회 - 상품 ID: {}", productId);
+
+        Page<BrokerReview> reviews = brokerReviewRepository.findLatestReviewsByProductId(productId, pageable);
+        return reviews.map(this::convertToListResponseDto);
+    }
+
+    @Override
+    public void deleteReview(Integer reviewId, Integer brokerId) {
+        log.info("리뷰 삭제 - 리뷰 ID: {}, 관세사 ID: {}", reviewId, brokerId);
+
+        BrokerReview review = brokerReviewRepository.findById(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리뷰입니다: " + reviewId));
+
+        // 권한 확인
+        if (!review.getBroker().getId().equals(brokerId)) {
+            throw new IllegalArgumentException("리뷰 삭제 권한이 없습니다");
+        }
+
+        brokerReviewRepository.delete(review);
+        log.info("리뷰 삭제 완료 - 리뷰 ID: {}", reviewId);
+    }
+
+    /**
+     * BrokerReview 엔티티를 BrokerReviewResponseDto로 변환
+     */
+    private BrokerReviewResponseDto convertToResponseDto(BrokerReview review) {
+        return BrokerReviewResponseDto.builder()
+                .id(review.getId())
+                .productId(review.getProduct().getId())
+                .productName(review.getProduct().getProductName())
+                .brokerId(review.getBroker().getId())
+                .brokerName(review.getBroker().getUserName())
+                .reviewStatus(review.getReviewStatus())
+                .reviewComment(review.getReviewComment())
+                .suggestedHsCode(review.getSuggestedHsCode())
+                .requestedAt(review.getRequestedAt())
+                .reviewedAt(review.getReviewedAt())
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
+                .build();
+    }
+
+    /**
+     * BrokerReview 엔티티를 BrokerReviewListResponseDto로 변환
+     */
+    private BrokerReviewListResponseDto convertToListResponseDto(BrokerReview review) {
+        return BrokerReviewListResponseDto.builder()
+                .id(review.getId())
+                .productId(review.getProduct().getId())
+                .productName(review.getProduct().getProductName())
+                .brokerId(review.getBroker().getId())
+                .brokerName(review.getBroker().getUserName())
+                .reviewStatus(review.getReviewStatus())
+                .reviewComment(review.getReviewComment())
+                .requestedAt(review.getRequestedAt())
+                .reviewedAt(review.getReviewedAt())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/suracle/backend_api/service/impl/ProductInquiryServiceImpl.java
+++ b/src/main/java/com/suracle/backend_api/service/impl/ProductInquiryServiceImpl.java
@@ -1,0 +1,166 @@
+package com.suracle.backend_api.service.impl;
+
+import com.suracle.backend_api.dto.inquiry.ProductInquiryRequestDto;
+import com.suracle.backend_api.dto.inquiry.ProductInquiryResponseDto;
+import com.suracle.backend_api.entity.inquiry.ProductInquiry;
+import com.suracle.backend_api.entity.product.Product;
+import com.suracle.backend_api.entity.user.User;
+import com.suracle.backend_api.repository.ProductInquiryRepository;
+import com.suracle.backend_api.repository.ProductRepository;
+import com.suracle.backend_api.repository.UserRepository;
+import com.suracle.backend_api.service.ProductInquiryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class ProductInquiryServiceImpl implements ProductInquiryService {
+
+    private final ProductInquiryRepository productInquiryRepository;
+    private final ProductRepository productRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public ProductInquiryResponseDto createInquiry(ProductInquiryRequestDto requestDto) {
+        log.info("문의 생성 - 사용자 ID: {}, 상품 ID: {}, 문의 유형: {}", 
+                requestDto.getUserId(), requestDto.getProductId(), requestDto.getInquiryType());
+
+        // 사용자 존재 확인
+        User user = userRepository.findById(requestDto.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다: " + requestDto.getUserId()));
+
+        // 상품 존재 확인 (상품 ID가 있는 경우)
+        Product product = null;
+        if (requestDto.getProductId() != null) {
+            product = productRepository.findById(requestDto.getProductId())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다: " + requestDto.getProductId()));
+        }
+
+        // 문의 생성
+        ProductInquiry inquiry = ProductInquiry.builder()
+                .user(user)
+                .product(product)
+                .inquiryType(requestDto.getInquiryType())
+                .inquiryData(requestDto.getInquiryData())
+                .aiResponse(requestDto.getAiResponse())
+                .responseSources(requestDto.getResponseSources())
+                .fromCache(requestDto.getFromCache())
+                .responseTimeMs(requestDto.getResponseTimeMs())
+                .build();
+
+        ProductInquiry savedInquiry = productInquiryRepository.save(inquiry);
+        log.info("문의 생성 완료 - 문의 ID: {}", savedInquiry.getId());
+
+        return convertToResponseDto(savedInquiry);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ProductInquiryResponseDto getInquiryById(Integer inquiryId) {
+        log.info("문의 상세 조회 - 문의 ID: {}", inquiryId);
+
+        ProductInquiry inquiry = productInquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 문의입니다: " + inquiryId));
+
+        return convertToResponseDto(inquiry);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ProductInquiryResponseDto> getInquiriesByUserId(Integer userId, Pageable pageable) {
+        log.info("사용자별 문의 목록 조회 - 사용자 ID: {}", userId);
+
+        Page<ProductInquiry> inquiries = productInquiryRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+        return inquiries.map(this::convertToResponseDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ProductInquiryResponseDto> getInquiriesByProductId(Integer productId, Pageable pageable) {
+        log.info("상품별 문의 목록 조회 - 상품 ID: {}", productId);
+
+        Page<ProductInquiry> inquiries = productInquiryRepository.findByProductIdOrderByCreatedAtDesc(productId, pageable);
+        return inquiries.map(this::convertToResponseDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ProductInquiryResponseDto> getInquiriesByType(com.suracle.backend_api.entity.inquiry.enums.InquiryType inquiryType, Pageable pageable) {
+        log.info("문의 유형별 목록 조회 - 문의 유형: {}", inquiryType);
+
+        Page<ProductInquiry> inquiries = productInquiryRepository.findByInquiryTypeOrderByCreatedAtDesc(inquiryType, pageable);
+        return inquiries.map(this::convertToResponseDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ProductInquiryResponseDto> getInquiriesByUserIdAndType(Integer userId, com.suracle.backend_api.entity.inquiry.enums.InquiryType inquiryType, Pageable pageable) {
+        log.info("사용자별 문의 유형별 조회 - 사용자 ID: {}, 문의 유형: {}", userId, inquiryType);
+
+        Page<ProductInquiry> inquiries = productInquiryRepository.findByUserIdAndInquiryTypeOrderByCreatedAtDesc(userId, inquiryType, pageable);
+        return inquiries.map(this::convertToResponseDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ProductInquiryResponseDto> getRecentInquiries(Pageable pageable) {
+        log.info("최근 문의 조회");
+
+        Page<ProductInquiry> inquiries = productInquiryRepository.findRecentInquiries(pageable);
+        return inquiries.map(this::convertToResponseDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ProductInquiryResponseDto> getInquiriesWithAiResponse(Pageable pageable) {
+        log.info("AI 응답이 있는 문의 조회");
+
+        Page<ProductInquiry> inquiries = productInquiryRepository.findInquiriesWithAiResponse(pageable);
+        return inquiries.map(this::convertToResponseDto);
+    }
+
+    @Override
+    public void deleteInquiry(Integer inquiryId, Integer userId) {
+        log.info("문의 삭제 - 문의 ID: {}, 사용자 ID: {}", inquiryId, userId);
+
+        ProductInquiry inquiry = productInquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 문의입니다: " + inquiryId));
+
+        // 권한 확인
+        if (!inquiry.getUser().getId().equals(userId)) {
+            throw new IllegalArgumentException("문의 삭제 권한이 없습니다");
+        }
+
+        productInquiryRepository.delete(inquiry);
+        log.info("문의 삭제 완료 - 문의 ID: {}", inquiryId);
+    }
+
+    /**
+     * ProductInquiry 엔티티를 ProductInquiryResponseDto로 변환
+     */
+    private ProductInquiryResponseDto convertToResponseDto(ProductInquiry inquiry) {
+        return ProductInquiryResponseDto.builder()
+                .id(inquiry.getId())
+                .userId(inquiry.getUser().getId())
+                .userName(inquiry.getUser().getUserName())
+                .productId(inquiry.getProduct() != null ? inquiry.getProduct().getId() : null)
+                .productName(inquiry.getProduct() != null ? inquiry.getProduct().getProductName() : null)
+                .inquiryType(inquiry.getInquiryType())
+                .inquiryData(inquiry.getInquiryData())
+                .aiResponse(inquiry.getAiResponse())
+                .responseSources(inquiry.getResponseSources())
+                .fromCache(inquiry.getFromCache())
+                .responseTimeMs(inquiry.getResponseTimeMs())
+                .createdAt(inquiry.getCreatedAt())
+                .updatedAt(inquiry.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/suracle/backend_api/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/suracle/backend_api/service/impl/ProductServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -258,6 +259,14 @@ public class ProductServiceImpl implements ProductService {
                 .createdAt(product.getCreatedAt())
                 .updatedAt(product.getUpdatedAt())
                 .build();
+    }
+
+    @Override
+    public Optional<ProductResponseDto> getProductById(Integer id) {
+        log.info("상품 조회 요청 (숫자 ID) - ID: {}", id);
+        
+        return productRepository.findById(id)
+                .map(this::convertToProductResponseDto);
     }
 
     /**


### PR DESCRIPTION
- BrokerReviewController 생성
- ProductController에 상품 ID 매핑 API 추가
- 상품 ID 매핑을 위한 getProductById(Integer id) 메서드 구현
- 관세사별 리뷰 목록 조회 기능 완성


DONE
- [x] 검토 목록 연결
- [x] 상품 상세보기 연결
- [x] 상태에 따라 버튼 변경(UI)

TODO
- [ ] 관세 판매자페이지 참고해서 연결
- [ ] 요건 판매자페이지 참고해서 연결
- [ ] 판례 판매자페이지 참고해서 연결
- [ ] 검토 요청 대시보드(목록)에 진행중, 완료 상태(버튼화) 누르면 필터링 되도록 구현
- [ ] 승인, 반려 api 구현(되어있는지 확인해야함!)
- [ ] 승인, 반려 api 연결
