### PR TITLE
feat: implement chat API with AI response service

### DIFF
--- a/src/main/java/com/suracle/backend_api/controller/ChatController.java
+++ b/src/main/java/com/suracle/backend_api/controller/ChatController.java
@@ -1,0 +1,235 @@
+package com.suracle.backend_api.controller;
+
+import com.suracle.backend_api.dto.chat.ChatMessageRequestDto;
+import com.suracle.backend_api.dto.chat.ChatMessageResponseDto;
+import com.suracle.backend_api.dto.chat.ChatSessionRequestDto;
+import com.suracle.backend_api.dto.chat.ChatSessionResponseDto;
+import com.suracle.backend_api.entity.chat.enums.ChatSessionStatus;
+import com.suracle.backend_api.entity.chat.enums.ChatSessionType;
+import com.suracle.backend_api.service.ChatService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+@Slf4j
+public class ChatController {
+
+    private final ChatService chatService;
+
+    /**
+     * 새 채팅 세션 생성
+     * @param requestDto 세션 생성 요청 정보
+     * @return 생성된 세션 정보
+     */
+    @PostMapping("/sessions")
+    public ResponseEntity<ChatSessionResponseDto> createSession(@Valid @RequestBody ChatSessionRequestDto requestDto) {
+        try {
+            log.info("새 채팅 세션 생성 요청 - 사용자 ID: {}, 세션 타입: {}", requestDto.getUserId(), requestDto.getSessionType());
+            ChatSessionResponseDto response = chatService.createSession(requestDto);
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("세션 생성 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        } catch (Exception e) {
+            log.error("세션 생성 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+    }
+
+    /**
+     * 세션 조회
+     * @param sessionId 세션 ID
+     * @return 세션 정보
+     */
+    @GetMapping("/sessions/{sessionId}")
+    public ResponseEntity<ChatSessionResponseDto> getSession(@PathVariable Integer sessionId) {
+        try {
+            log.info("세션 조회 요청 - 세션 ID: {}", sessionId);
+            ChatSessionResponseDto response = chatService.getSession(sessionId);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("세션 조회 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        } catch (Exception e) {
+            log.error("세션 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+    }
+
+    /**
+     * 사용자의 활성 세션 조회
+     * @param userId 사용자 ID
+     * @param sessionType 세션 타입 (선택사항)
+     * @return 활성 세션 목록
+     */
+    @GetMapping("/sessions")
+    public ResponseEntity<List<ChatSessionResponseDto>> getActiveSessions(
+            @RequestParam Integer userId,
+            @RequestParam(required = false) ChatSessionType sessionType) {
+        try {
+            log.info("활성 세션 조회 요청 - 사용자 ID: {}, 세션 타입: {}", userId, sessionType);
+            List<ChatSessionResponseDto> responses = chatService.getActiveSessions(userId, sessionType);
+            return ResponseEntity.ok(responses);
+        } catch (Exception e) {
+            log.error("활성 세션 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 세션 상태 업데이트
+     * @param sessionId 세션 ID
+     * @param status 새로운 상태
+     * @param sessionData 세션 데이터 (선택사항)
+     * @return 업데이트된 세션 정보
+     */
+    @PutMapping("/sessions/{sessionId}")
+    public ResponseEntity<ChatSessionResponseDto> updateSession(
+            @PathVariable Integer sessionId,
+            @RequestParam ChatSessionStatus status,
+            @RequestParam(required = false) String sessionData) {
+        try {
+            log.info("세션 업데이트 요청 - 세션 ID: {}, 상태: {}", sessionId, status);
+            ChatSessionResponseDto response = chatService.updateSession(sessionId, status, sessionData);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("세션 업데이트 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        } catch (Exception e) {
+            log.error("세션 업데이트 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+    }
+
+    /**
+     * 메시지 전송
+     * @param sessionId 세션 ID
+     * @param requestDto 메시지 전송 요청 정보
+     * @return 전송된 메시지 정보
+     */
+    @PostMapping("/sessions/{sessionId}/messages")
+    public ResponseEntity<ChatMessageResponseDto> sendMessage(
+            @PathVariable Integer sessionId,
+            @Valid @RequestBody ChatMessageRequestDto requestDto) {
+        try {
+            log.info("메시지 전송 요청 - 세션 ID: {}, 발신자: {}", sessionId, requestDto.getSenderType());
+            
+            // 세션 ID 설정
+            requestDto.setSessionId(sessionId);
+            
+            ChatMessageResponseDto response = chatService.sendMessage(requestDto);
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("메시지 전송 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        } catch (Exception e) {
+            log.error("메시지 전송 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+    }
+
+    /**
+     * 세션의 메시지 목록 조회 (페이징)
+     * @param sessionId 세션 ID
+     * @param page 페이지 번호 (기본값: 0)
+     * @param size 페이지 크기 (기본값: 20)
+     * @param sort 정렬 기준 (기본값: createdAt,asc)
+     * @return 메시지 목록
+     */
+    @GetMapping("/sessions/{sessionId}/messages")
+    public ResponseEntity<Page<ChatMessageResponseDto>> getMessages(
+            @PathVariable Integer sessionId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "createdAt,asc") String sort) {
+        try {
+            log.info("메시지 목록 조회 요청 - 세션 ID: {}, 페이지: {}, 크기: {}", sessionId, page, size);
+            
+            String[] sortParams = sort.split(",");
+            Sort.Direction direction = sortParams.length > 1 && "desc".equalsIgnoreCase(sortParams[1]) 
+                    ? Sort.Direction.DESC : Sort.Direction.ASC;
+            Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortParams[0]));
+            
+            Page<ChatMessageResponseDto> responses = chatService.getMessages(sessionId, pageable);
+            return ResponseEntity.ok(responses);
+        } catch (IllegalArgumentException e) {
+            log.warn("메시지 조회 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        } catch (Exception e) {
+            log.error("메시지 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * 세션의 모든 메시지 조회 (페이징 없이)
+     * @param sessionId 세션 ID
+     * @return 메시지 목록
+     */
+    @GetMapping("/sessions/{sessionId}/messages/all")
+    public ResponseEntity<List<ChatMessageResponseDto>> getAllMessages(@PathVariable Integer sessionId) {
+        try {
+            log.info("모든 메시지 조회 요청 - 세션 ID: {}", sessionId);
+            List<ChatMessageResponseDto> responses = chatService.getAllMessages(sessionId);
+            return ResponseEntity.ok(responses);
+        } catch (IllegalArgumentException e) {
+            log.warn("메시지 조회 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        } catch (Exception e) {
+            log.error("메시지 조회 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * AI 응답 생성
+     * @param sessionId 세션 ID
+     * @param userMessage 사용자 메시지
+     * @return AI 응답 메시지
+     */
+    @PostMapping("/sessions/{sessionId}/ai-response")
+    public ResponseEntity<ChatMessageResponseDto> generateAiResponse(
+            @PathVariable Integer sessionId,
+            @RequestParam String userMessage) {
+        try {
+            log.info("AI 응답 생성 요청 - 세션 ID: {}, 사용자 메시지: {}", sessionId, userMessage);
+            ChatMessageResponseDto response = chatService.generateAiResponse(sessionId, userMessage);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("AI 응답 생성 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        } catch (Exception e) {
+            log.error("AI 응답 생성 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+    }
+
+    /**
+     * 만료된 데이터 정리 (관리자용)
+     * @param expiredHours 만료 시간 (시간 단위, 기본값: 24)
+     * @return 정리된 항목 수
+     */
+    @PostMapping("/cleanup")
+    public ResponseEntity<Integer> cleanupExpiredData(@RequestParam(defaultValue = "24") int expiredHours) {
+        try {
+            log.info("만료된 데이터 정리 요청 - 만료 시간: {}시간", expiredHours);
+            int cleanedCount = chatService.cleanupExpiredData(expiredHours);
+            return ResponseEntity.ok(cleanedCount);
+        } catch (Exception e) {
+            log.error("데이터 정리 중 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/src/main/java/com/suracle/backend_api/dto/chat/ChatMessageRequestDto.java
+++ b/src/main/java/com/suracle/backend_api/dto/chat/ChatMessageRequestDto.java
@@ -1,0 +1,30 @@
+package com.suracle.backend_api.dto.chat;
+
+import com.suracle.backend_api.entity.chat.enums.MessageSenderType;
+import com.suracle.backend_api.entity.chat.enums.MessageType;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageRequestDto {
+    
+    @NotNull(message = "세션 ID는 필수입니다")
+    private Integer sessionId;
+    
+    @NotNull(message = "발신자 타입은 필수입니다")
+    private MessageSenderType senderType;
+    
+    @NotNull(message = "메시지 내용은 필수입니다")
+    private String messageContent;
+    
+    @NotNull(message = "메시지 타입은 필수입니다")
+    private MessageType messageType;
+    
+    private String metadata;
+}

--- a/src/main/java/com/suracle/backend_api/dto/chat/ChatMessageResponseDto.java
+++ b/src/main/java/com/suracle/backend_api/dto/chat/ChatMessageResponseDto.java
@@ -1,0 +1,25 @@
+package com.suracle.backend_api.dto.chat;
+
+import com.suracle.backend_api.entity.chat.enums.MessageSenderType;
+import com.suracle.backend_api.entity.chat.enums.MessageType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageResponseDto {
+    
+    private Integer id;
+    private Integer sessionId;
+    private MessageSenderType senderType;
+    private String messageContent;
+    private MessageType messageType;
+    private String metadata;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/suracle/backend_api/dto/chat/ChatSessionRequestDto.java
+++ b/src/main/java/com/suracle/backend_api/dto/chat/ChatSessionRequestDto.java
@@ -1,0 +1,26 @@
+package com.suracle.backend_api.dto.chat;
+
+import com.suracle.backend_api.entity.chat.enums.ChatSessionType;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatSessionRequestDto {
+    
+    @NotNull(message = "사용자 ID는 필수입니다")
+    private Integer userId;
+    
+    @NotNull(message = "세션 타입은 필수입니다")
+    private ChatSessionType sessionType;
+    
+    @NotNull(message = "언어는 필수입니다")
+    private String language;
+    
+    private String sessionData;
+}

--- a/src/main/java/com/suracle/backend_api/dto/chat/ChatSessionResponseDto.java
+++ b/src/main/java/com/suracle/backend_api/dto/chat/ChatSessionResponseDto.java
@@ -1,0 +1,27 @@
+package com.suracle.backend_api.dto.chat;
+
+import com.suracle.backend_api.entity.chat.enums.ChatSessionStatus;
+import com.suracle.backend_api.entity.chat.enums.ChatSessionType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatSessionResponseDto {
+    
+    private Integer id;
+    private Integer userId;
+    private String userName;
+    private ChatSessionType sessionType;
+    private String language;
+    private ChatSessionStatus status;
+    private String sessionData;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/suracle/backend_api/repository/ChatMessageRepository.java
+++ b/src/main/java/com/suracle/backend_api/repository/ChatMessageRepository.java
@@ -1,0 +1,65 @@
+package com.suracle.backend_api.repository;
+
+import com.suracle.backend_api.entity.chat.ChatMessage;
+import com.suracle.backend_api.entity.chat.enums.MessageSenderType;
+import com.suracle.backend_api.entity.chat.enums.MessageType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Integer> {
+    
+    /**
+     * 세션 ID로 메시지 목록 조회 (최신순)
+     * @param sessionId 세션 ID
+     * @param pageable 페이징 정보
+     * @return 메시지 목록
+     */
+    Page<ChatMessage> findBySessionIdOrderByCreatedAtAsc(Integer sessionId, Pageable pageable);
+    
+    /**
+     * 세션 ID로 메시지 목록 조회 (페이징 없이)
+     * @param sessionId 세션 ID
+     * @return 메시지 목록
+     */
+    List<ChatMessage> findBySessionIdOrderByCreatedAtAsc(Integer sessionId);
+    
+    /**
+     * 세션 ID와 발신자 타입으로 메시지 조회
+     * @param sessionId 세션 ID
+     * @param senderType 발신자 타입
+     * @return 메시지 목록
+     */
+    List<ChatMessage> findBySessionIdAndSenderTypeOrderByCreatedAtAsc(Integer sessionId, MessageSenderType senderType);
+    
+    /**
+     * 세션 ID와 메시지 타입으로 메시지 조회
+     * @param sessionId 세션 ID
+     * @param messageType 메시지 타입
+     * @return 메시지 목록
+     */
+    List<ChatMessage> findBySessionIdAndMessageTypeOrderByCreatedAtAsc(Integer sessionId, MessageType messageType);
+    
+    /**
+     * 만료된 메시지 조회 (일정 시간 이전에 생성된 메시지)
+     * @param expiredTime 만료 시간
+     * @return 만료된 메시지 목록
+     */
+    @Query("SELECT cm FROM ChatMessage cm WHERE cm.createdAt < :expiredTime")
+    List<ChatMessage> findExpiredMessages(@Param("expiredTime") LocalDateTime expiredTime);
+    
+    /**
+     * 세션의 마지막 메시지 조회
+     * @param sessionId 세션 ID
+     * @return 마지막 메시지
+     */
+    @Query("SELECT cm FROM ChatMessage cm WHERE cm.session.id = :sessionId ORDER BY cm.createdAt DESC LIMIT 1")
+    ChatMessage findLastMessageBySessionId(@Param("sessionId") Integer sessionId);
+}

--- a/src/main/java/com/suracle/backend_api/repository/ChatSessionRepository.java
+++ b/src/main/java/com/suracle/backend_api/repository/ChatSessionRepository.java
@@ -1,0 +1,50 @@
+package com.suracle.backend_api.repository;
+
+import com.suracle.backend_api.entity.chat.ChatSession;
+import com.suracle.backend_api.entity.chat.enums.ChatSessionStatus;
+import com.suracle.backend_api.entity.chat.enums.ChatSessionType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ChatSessionRepository extends JpaRepository<ChatSession, Integer> {
+    
+    /**
+     * 사용자 ID로 활성 세션 조회
+     * @param userId 사용자 ID
+     * @param status 세션 상태
+     * @return 활성 세션 목록
+     */
+    List<ChatSession> findByUserIdAndStatusOrderByCreatedAtDesc(Integer userId, ChatSessionStatus status);
+    
+    /**
+     * 사용자 ID와 세션 타입으로 활성 세션 조회
+     * @param userId 사용자 ID
+     * @param sessionType 세션 타입
+     * @param status 세션 상태
+     * @return 활성 세션 목록
+     */
+    List<ChatSession> findByUserIdAndSessionTypeAndStatusOrderByCreatedAtDesc(
+            Integer userId, ChatSessionType sessionType, ChatSessionStatus status);
+    
+    /**
+     * 만료된 세션 조회 (일정 시간 이전에 생성된 세션)
+     * @param expiredTime 만료 시간
+     * @return 만료된 세션 목록
+     */
+    @Query("SELECT cs FROM ChatSession cs WHERE cs.createdAt < :expiredTime")
+    List<ChatSession> findExpiredSessions(@Param("expiredTime") LocalDateTime expiredTime);
+    
+    /**
+     * 사용자 ID로 최근 세션 조회
+     * @param userId 사용자 ID
+     * @return 최근 세션
+     */
+    Optional<ChatSession> findFirstByUserIdOrderByCreatedAtDesc(Integer userId);
+}

--- a/src/main/java/com/suracle/backend_api/repository/ProductRepository.java
+++ b/src/main/java/com/suracle/backend_api/repository/ProductRepository.java
@@ -62,4 +62,10 @@ public interface ProductRepository extends JpaRepository<Product, Integer> {
      */
     @Query("SELECT p FROM Product p WHERE p.seller.id = :sellerId AND (:productName IS NULL OR :productName = '' OR LOWER(p.productName) LIKE LOWER(CONCAT('%', :productName, '%'))) AND p.isActive = true AND (:status IS NULL OR p.status = :status)")
     Page<Product> findBySellerIdAndProductNameContainingAndStatusAndIsActiveTrue(@Param("sellerId") Integer sellerId, @Param("productName") String productName, @Param("status") ProductStatus status, Pageable pageable);
+
+    /**
+     * 상품명으로 검색 (대소문자 구분 없음, 단일 결과)
+     */
+    @Query("SELECT p FROM Product p WHERE LOWER(p.productName) LIKE LOWER(CONCAT('%', :productName, '%')) AND p.isActive = true")
+    Optional<Product> findByProductNameContainingIgnoreCase(@Param("productName") String productName);
 }

--- a/src/main/java/com/suracle/backend_api/service/ChatService.java
+++ b/src/main/java/com/suracle/backend_api/service/ChatService.java
@@ -1,0 +1,83 @@
+package com.suracle.backend_api.service;
+
+import com.suracle.backend_api.dto.chat.ChatMessageRequestDto;
+import com.suracle.backend_api.dto.chat.ChatMessageResponseDto;
+import com.suracle.backend_api.dto.chat.ChatSessionRequestDto;
+import com.suracle.backend_api.dto.chat.ChatSessionResponseDto;
+import com.suracle.backend_api.entity.chat.enums.ChatSessionStatus;
+import com.suracle.backend_api.entity.chat.enums.ChatSessionType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface ChatService {
+    
+    /**
+     * 새 채팅 세션 생성
+     * @param requestDto 세션 생성 요청 정보
+     * @return 생성된 세션 정보
+     */
+    ChatSessionResponseDto createSession(ChatSessionRequestDto requestDto);
+    
+    /**
+     * 세션 조회
+     * @param sessionId 세션 ID
+     * @return 세션 정보
+     */
+    ChatSessionResponseDto getSession(Integer sessionId);
+    
+    /**
+     * 사용자의 활성 세션 조회
+     * @param userId 사용자 ID
+     * @param sessionType 세션 타입 (선택사항)
+     * @return 활성 세션 목록
+     */
+    List<ChatSessionResponseDto> getActiveSessions(Integer userId, ChatSessionType sessionType);
+    
+    /**
+     * 세션 상태 업데이트
+     * @param sessionId 세션 ID
+     * @param status 새로운 상태
+     * @param sessionData 세션 데이터 (선택사항)
+     * @return 업데이트된 세션 정보
+     */
+    ChatSessionResponseDto updateSession(Integer sessionId, ChatSessionStatus status, String sessionData);
+    
+    /**
+     * 메시지 전송
+     * @param requestDto 메시지 전송 요청 정보
+     * @return 전송된 메시지 정보
+     */
+    ChatMessageResponseDto sendMessage(ChatMessageRequestDto requestDto);
+    
+    /**
+     * 세션의 메시지 목록 조회
+     * @param sessionId 세션 ID
+     * @param pageable 페이징 정보
+     * @return 메시지 목록
+     */
+    Page<ChatMessageResponseDto> getMessages(Integer sessionId, Pageable pageable);
+    
+    /**
+     * 세션의 모든 메시지 조회 (페이징 없이)
+     * @param sessionId 세션 ID
+     * @return 메시지 목록
+     */
+    List<ChatMessageResponseDto> getAllMessages(Integer sessionId);
+    
+    /**
+     * 만료된 세션 및 메시지 정리
+     * @param expiredHours 만료 시간 (시간 단위)
+     * @return 정리된 세션 수
+     */
+    int cleanupExpiredData(int expiredHours);
+    
+    /**
+     * 샘플 데이터 기반 AI 응답 생성
+     * @param sessionId 세션 ID
+     * @param userMessage 사용자 메시지
+     * @return AI 응답 메시지
+     */
+    ChatMessageResponseDto generateAiResponse(Integer sessionId, String userMessage);
+}

--- a/src/main/java/com/suracle/backend_api/service/impl/ChatAiService.java
+++ b/src/main/java/com/suracle/backend_api/service/impl/ChatAiService.java
@@ -1,0 +1,326 @@
+package com.suracle.backend_api.service.impl;
+
+import com.suracle.backend_api.entity.chat.ChatSession;
+import com.suracle.backend_api.entity.product.Product;
+import com.suracle.backend_api.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 샘플 데이터 기반 AI 응답 서비스 (MVP용)
+ * 추후 실제 AI 서비스로 대체 예정
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatAiService {
+
+    private final ProductRepository productRepository;
+
+    /**
+     * 사용자 메시지에 대한 AI 응답 생성
+     * @param session 채팅 세션
+     * @param userMessage 사용자 메시지
+     * @return AI 응답
+     */
+    public String generateResponse(ChatSession session, String userMessage) {
+        log.info("AI 응답 생성 - 세션 타입: {}, 사용자 메시지: {}", session.getSessionType(), userMessage);
+        
+        String lowerMessage = userMessage.toLowerCase().trim();
+        
+        // 사용자 유형별 응답 분기
+        switch (session.getSessionType()) {
+            case SELLER_PRODUCT_INQUIRY:
+                return generateSellerResponse(session, lowerMessage);
+            case BUYER_PURCHASE_INQUIRY:
+                return generateBuyerResponse(session, lowerMessage);
+            default:
+                return generateGeneralResponse(lowerMessage);
+        }
+    }
+
+    /**
+     * 판매자용 응답 생성
+     */
+    private String generateSellerResponse(ChatSession session, String userMessage) {
+        // 상품명 검색
+        if (containsProductKeywords(userMessage)) {
+            String productName = extractProductName(userMessage);
+            if (productName != null) {
+                return generateProductInquiryResponse(productName, userMessage);
+            }
+        }
+        
+        // 일반적인 판매자 문의 응답
+        if (userMessage.contains("안녕") || userMessage.contains("hello")) {
+            return "안녕하세요! 판매자님의 상품 등록을 도와드리겠습니다. 어떤 상품에 대해 문의하시나요?";
+        } else if (userMessage.contains("상품") || userMessage.contains("product")) {
+            return "상품에 대한 문의를 도와드리겠습니다. 상품명을 알려주시면 HS코드, 관세, 요건, 판례 정보를 제공해드릴 수 있습니다.";
+        } else if (userMessage.contains("관세") || userMessage.contains("tariff")) {
+            return "관세 정보를 제공해드리겠습니다. 어떤 상품의 관세를 알고 싶으신가요?";
+        } else if (userMessage.contains("요건") || userMessage.contains("requirement")) {
+            return "수입 요건에 대해 안내해드리겠습니다. 구체적인 상품을 말씀해주세요.";
+        } else if (userMessage.contains("판례") || userMessage.contains("precedent")) {
+            return "관련 판례 정보를 제공해드리겠습니다. 어떤 상품의 판례를 찾고 계신가요?";
+        } else {
+            return "판매자님의 상품 등록을 도와드리겠습니다. 구체적인 질문을 해주시면 더 정확한 답변을 드릴 수 있습니다.";
+        }
+    }
+
+    /**
+     * 구매자용 응답 생성
+     */
+    private String generateBuyerResponse(ChatSession session, String userMessage) {
+        // 상품명 검색
+        if (containsProductKeywords(userMessage)) {
+            String productName = extractProductName(userMessage);
+            if (productName != null) {
+                return generateBuyerProductResponse(productName, userMessage);
+            }
+        }
+        
+        // 일반적인 구매자 문의 응답
+        if (userMessage.contains("안녕") || userMessage.contains("hello")) {
+            return "Hello! I'm here to help you with your import inquiries. What product are you interested in?";
+        } else if (userMessage.contains("product") || userMessage.contains("상품")) {
+            return "I can help you with product information. Please tell me the product name you're interested in.";
+        } else if (userMessage.contains("requirement") || userMessage.contains("요건")) {
+            return "I can provide import requirements information. Which product do you want to know about?";
+        } else if (userMessage.contains("tariff") || userMessage.contains("관세")) {
+            return "I can help you calculate tariffs. Please specify the product and quantity.";
+        } else {
+            return "I'm here to help with your import inquiries. Please ask me about specific products or requirements.";
+        }
+    }
+
+    /**
+     * 일반 응답 생성
+     */
+    private String generateGeneralResponse(String userMessage) {
+        if (userMessage.contains("안녕") || userMessage.contains("hello")) {
+            return "안녕하세요! AI 무역 어시스턴트입니다. 어떤 도움이 필요하신가요?";
+        } else {
+            return "죄송합니다. 더 구체적인 질문을 해주시면 도움을 드릴 수 있습니다.";
+        }
+    }
+
+    /**
+     * 상품명이 포함된 키워드 확인
+     */
+    private boolean containsProductKeywords(String userMessage) {
+        List<String> productKeywords = Arrays.asList(
+            "premium vitamin c serum", "비타민c 세럼",
+            "hydrating snail cream", "달팽이 크림",
+            "premium red ginseng extract", "홍삼 추출액",
+            "instant cooked rice", "즉석밥",
+            "rice snack", "쌀 과자",
+            "instant ramyeon", "즉석라면",
+            "bbq seasoning", "바비큐 시즈닝",
+            "kimchi", "김치",
+            "perfume", "향수"
+        );
+        
+        return productKeywords.stream().anyMatch(userMessage::contains);
+    }
+
+    /**
+     * 사용자 메시지에서 상품명 추출
+     */
+    private String extractProductName(String userMessage) {
+        // 샘플 데이터의 상품명들과 매칭
+        if (userMessage.contains("premium vitamin c serum") || userMessage.contains("비타민c 세럼")) {
+            return "Premium Vitamin C Serum";
+        } else if (userMessage.contains("hydrating snail cream") || userMessage.contains("달팽이 크림")) {
+            return "Hydrating Snail Cream";
+        } else if (userMessage.contains("premium red ginseng extract") || userMessage.contains("홍삼 추출액")) {
+            return "Premium Red Ginseng Extract";
+        } else if (userMessage.contains("instant cooked rice") || userMessage.contains("즉석밥")) {
+            return "Instant Cooked Rice Multipack";
+        } else if (userMessage.contains("rice snack") || userMessage.contains("쌀 과자")) {
+            return "Korean Rice Snack Assorted Pack";
+        } else if (userMessage.contains("instant ramyeon") || userMessage.contains("즉석라면")) {
+            return "Premium Instant Ramyeon 4-Pack";
+        } else if (userMessage.contains("bbq seasoning") || userMessage.contains("바비큐 시즈닝")) {
+            return "Korean BBQ Seasoning Mix";
+        } else if (userMessage.contains("kimchi") || userMessage.contains("김치")) {
+            return "Fermented Cabbage Kimchi";
+        } else if (userMessage.contains("perfume") || userMessage.contains("향수")) {
+            return "Rose Garden Perfume 50ml";
+        }
+        
+        return null;
+    }
+
+    /**
+     * 상품 문의 응답 생성
+     */
+    private String generateProductInquiryResponse(String productName, String userMessage) {
+        // 실제 상품 검색
+        Optional<Product> productOpt = productRepository.findByProductNameContainingIgnoreCase(productName);
+        
+        if (productOpt.isPresent()) {
+            Product product = productOpt.get();
+            
+            if (userMessage.contains("관세") || userMessage.contains("tariff")) {
+                return generateTariffResponse(product);
+            } else if (userMessage.contains("요건") || userMessage.contains("requirement")) {
+                return generateRequirementResponse(product);
+            } else if (userMessage.contains("판례") || userMessage.contains("precedent")) {
+                return generatePrecedentResponse(product);
+            } else if (userMessage.contains("hs코드") || userMessage.contains("hs code")) {
+                return generateHsCodeResponse(product);
+            } else {
+                return generateGeneralProductResponse(product);
+            }
+        } else {
+            return "죄송합니다. '" + productName + "' 상품을 찾을 수 없습니다. 정확한 상품명을 확인해주세요.";
+        }
+    }
+
+    /**
+     * 구매자 상품 응답 생성
+     */
+    private String generateBuyerProductResponse(String productName, String userMessage) {
+        Optional<Product> productOpt = productRepository.findByProductNameContainingIgnoreCase(productName);
+        
+        if (productOpt.isPresent()) {
+            Product product = productOpt.get();
+            
+            if (userMessage.contains("requirement") || userMessage.contains("요건")) {
+                return generateBuyerRequirementResponse(product);
+            } else if (userMessage.contains("tariff") || userMessage.contains("관세")) {
+                return generateBuyerTariffResponse(product);
+            } else {
+                return generateBuyerGeneralResponse(product);
+            }
+        } else {
+            return "I couldn't find the product '" + productName + "'. Please check the product name and try again.";
+        }
+    }
+
+    /**
+     * 관세 응답 생성
+     */
+    private String generateTariffResponse(Product product) {
+        return String.format("'%s' 상품의 관세 정보입니다:\n\n" +
+                "• HS코드: %s\n" +
+                "• 단가: $%.2f\n" +
+                "• FOB 가격: $%.2f\n" +
+                "• 관세율: 15%% (상호관세 적용)\n" +
+                "• 1개 수입시 총 비용: $%.2f\n\n" +
+                "상호관세로 인해 15%% 관세가 부과되므로 가격 경쟁력을 재검토하시기 바랍니다.",
+                product.getProductName(),
+                product.getHsCode(),
+                product.getPrice(),
+                product.getFobPrice(),
+                product.getFobPrice().multiply(java.math.BigDecimal.valueOf(1.15)));
+    }
+
+    /**
+     * 요건 응답 생성
+     */
+    private String generateRequirementResponse(Product product) {
+        return String.format("'%s' 상품의 수입 요건입니다:\n\n" +
+                "• FDA 등록 필수\n" +
+                "• 성분 안전성 평가 필요\n" +
+                "• 21 CFR 701 라벨링 준수\n" +
+                "• VCRP 자발적 등록 권장\n\n" +
+                "상세한 요건은 상품 유형에 따라 달라질 수 있습니다.",
+                product.getProductName());
+    }
+
+    /**
+     * 판례 응답 생성
+     */
+    private String generatePrecedentResponse(Product product) {
+        return String.format("'%s' 상품의 관련 판례입니다:\n\n" +
+                "• 2024년 4월 유사 제품 승인 사례\n" +
+                "• 농도 검증 및 안정성 테스트 완료로 통과\n" +
+                "• pH 테스트 및 자극성 테스트 중요\n\n" +
+                "성분 농도는 반드시 HPLC 분석법으로 검증하시기 바랍니다.",
+                product.getProductName());
+    }
+
+    /**
+     * HS코드 응답 생성
+     */
+    private String generateHsCodeResponse(Product product) {
+        return String.format("'%s' 상품의 HS코드 정보입니다:\n\n" +
+                "• HS코드: %s\n" +
+                "• 분류: 기타 미용 또는 메이크업 제품\n" +
+                "• 설명: 안티에이징 페이셜 세럼\n\n" +
+                "이 분류는 FDA 화장품 규정을 따릅니다.",
+                product.getProductName(),
+                product.getHsCode());
+    }
+
+    /**
+     * 일반 상품 응답 생성
+     */
+    private String generateGeneralProductResponse(Product product) {
+        return String.format("'%s' 상품 정보입니다:\n\n" +
+                "• HS코드: %s\n" +
+                "• 가격: $%.2f\n" +
+                "• FOB 가격: $%.2f\n" +
+                "• 원산지: %s\n\n" +
+                "어떤 정보가 더 필요하신가요? (HS코드, 관세, 요건, 판례)",
+                product.getProductName(),
+                product.getHsCode(),
+                product.getPrice(),
+                product.getFobPrice(),
+                product.getOriginCountry());
+    }
+
+    /**
+     * 구매자 요건 응답 생성
+     */
+    private String generateBuyerRequirementResponse(Product product) {
+        return String.format("For importing '%s' to the US:\n\n" +
+                "• FDA Prior Notice required\n" +
+                "• Facility registration needed\n" +
+                "• Labeling compliance (21 CFR 701)\n" +
+                "• Ingredient safety assessment\n\n" +
+                "Please ensure all requirements are met before import.",
+                product.getProductName());
+    }
+
+    /**
+     * 구매자 관세 응답 생성
+     */
+    private String generateBuyerTariffResponse(Product product) {
+        return String.format("Tariff information for '%s':\n\n" +
+                "• HS Code: %s\n" +
+                "• Unit Price: $%.2f\n" +
+                "• FOB Price: $%.2f\n" +
+                "• Tariff Rate: 15%% (retaliatory tariff)\n" +
+                "• Total cost per unit: $%.2f\n\n" +
+                "Consider the tariff impact on your pricing strategy.",
+                product.getProductName(),
+                product.getHsCode(),
+                product.getPrice(),
+                product.getFobPrice(),
+                product.getFobPrice().multiply(java.math.BigDecimal.valueOf(1.15)));
+    }
+
+    /**
+     * 구매자 일반 응답 생성
+     */
+    private String generateBuyerGeneralResponse(Product product) {
+        return String.format("Product information for '%s':\n\n" +
+                "• HS Code: %s\n" +
+                "• Price: $%.2f\n" +
+                "• FOB Price: $%.2f\n" +
+                "• Origin: %s\n\n" +
+                "What specific information do you need? (requirements, tariffs, precedents)",
+                product.getProductName(),
+                product.getHsCode(),
+                product.getPrice(),
+                product.getFobPrice(),
+                product.getOriginCountry());
+    }
+}

--- a/src/main/java/com/suracle/backend_api/service/impl/ChatServiceImpl.java
+++ b/src/main/java/com/suracle/backend_api/service/impl/ChatServiceImpl.java
@@ -1,0 +1,258 @@
+package com.suracle.backend_api.service.impl;
+
+import com.suracle.backend_api.dto.chat.ChatMessageRequestDto;
+import com.suracle.backend_api.dto.chat.ChatMessageResponseDto;
+import com.suracle.backend_api.dto.chat.ChatSessionRequestDto;
+import com.suracle.backend_api.dto.chat.ChatSessionResponseDto;
+import com.suracle.backend_api.entity.chat.ChatMessage;
+import com.suracle.backend_api.entity.chat.ChatSession;
+import com.suracle.backend_api.entity.chat.enums.ChatSessionStatus;
+import com.suracle.backend_api.entity.chat.enums.ChatSessionType;
+import com.suracle.backend_api.entity.chat.enums.MessageSenderType;
+import com.suracle.backend_api.entity.chat.enums.MessageType;
+import com.suracle.backend_api.entity.user.User;
+import com.suracle.backend_api.repository.ChatMessageRepository;
+import com.suracle.backend_api.repository.ChatSessionRepository;
+import com.suracle.backend_api.repository.UserRepository;
+import com.suracle.backend_api.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class ChatServiceImpl implements ChatService {
+
+    private final ChatSessionRepository chatSessionRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
+    private final ChatAiService chatAiService;
+
+    @Override
+    public ChatSessionResponseDto createSession(ChatSessionRequestDto requestDto) {
+        log.info("새 채팅 세션 생성 요청 - 사용자 ID: {}, 세션 타입: {}", requestDto.getUserId(), requestDto.getSessionType());
+        
+        // 사용자 존재 확인
+        User user = userRepository.findById(requestDto.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다: " + requestDto.getUserId()));
+        
+        // 기존 활성 세션이 있는지 확인 (같은 타입의 세션)
+        List<ChatSession> existingSessions = chatSessionRepository.findByUserIdAndSessionTypeAndStatusOrderByCreatedAtDesc(
+                requestDto.getUserId(), requestDto.getSessionType(), ChatSessionStatus.ACTIVE);
+        
+        if (!existingSessions.isEmpty()) {
+            log.info("기존 활성 세션 발견 - 세션 ID: {}", existingSessions.get(0).getId());
+            return convertToSessionResponseDto(existingSessions.get(0));
+        }
+        
+        // 새 세션 생성
+        ChatSession session = ChatSession.builder()
+                .user(user)
+                .sessionType(requestDto.getSessionType())
+                .language(requestDto.getLanguage())
+                .status(ChatSessionStatus.ACTIVE)
+                .sessionData(requestDto.getSessionData())
+                .build();
+        
+        ChatSession savedSession = chatSessionRepository.save(session);
+        log.info("새 채팅 세션 생성 완료 - 세션 ID: {}", savedSession.getId());
+        
+        return convertToSessionResponseDto(savedSession);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ChatSessionResponseDto getSession(Integer sessionId) {
+        log.info("세션 조회 요청 - 세션 ID: {}", sessionId);
+        
+        ChatSession session = chatSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 세션입니다: " + sessionId));
+        
+        return convertToSessionResponseDto(session);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ChatSessionResponseDto> getActiveSessions(Integer userId, ChatSessionType sessionType) {
+        log.info("활성 세션 조회 요청 - 사용자 ID: {}, 세션 타입: {}", userId, sessionType);
+        
+        List<ChatSession> sessions;
+        if (sessionType != null) {
+            sessions = chatSessionRepository.findByUserIdAndSessionTypeAndStatusOrderByCreatedAtDesc(
+                    userId, sessionType, ChatSessionStatus.ACTIVE);
+        } else {
+            sessions = chatSessionRepository.findByUserIdAndStatusOrderByCreatedAtDesc(
+                    userId, ChatSessionStatus.ACTIVE);
+        }
+        
+        return sessions.stream()
+                .map(this::convertToSessionResponseDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public ChatSessionResponseDto updateSession(Integer sessionId, ChatSessionStatus status, String sessionData) {
+        log.info("세션 업데이트 요청 - 세션 ID: {}, 상태: {}", sessionId, status);
+        
+        ChatSession session = chatSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 세션입니다: " + sessionId));
+        
+        session.setStatus(status);
+        if (sessionData != null) {
+            session.setSessionData(sessionData);
+        }
+        
+        ChatSession updatedSession = chatSessionRepository.save(session);
+        log.info("세션 업데이트 완료 - 세션 ID: {}", updatedSession.getId());
+        
+        return convertToSessionResponseDto(updatedSession);
+    }
+
+    @Override
+    public ChatMessageResponseDto sendMessage(ChatMessageRequestDto requestDto) {
+        log.info("메시지 전송 요청 - 세션 ID: {}, 발신자: {}", requestDto.getSessionId(), requestDto.getSenderType());
+        
+        // 세션 존재 확인
+        ChatSession session = chatSessionRepository.findById(requestDto.getSessionId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 세션입니다: " + requestDto.getSessionId()));
+        
+        // 메시지 생성
+        ChatMessage message = ChatMessage.builder()
+                .session(session)
+                .senderType(requestDto.getSenderType())
+                .messageContent(requestDto.getMessageContent())
+                .messageType(requestDto.getMessageType())
+                .metadata(requestDto.getMetadata())
+                .build();
+        
+        ChatMessage savedMessage = chatMessageRepository.save(message);
+        log.info("메시지 전송 완료 - 메시지 ID: {}", savedMessage.getId());
+        
+        return convertToMessageResponseDto(savedMessage);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ChatMessageResponseDto> getMessages(Integer sessionId, Pageable pageable) {
+        log.info("메시지 목록 조회 요청 - 세션 ID: {}, 페이지: {}", sessionId, pageable.getPageNumber());
+        
+        // 세션 존재 확인
+        chatSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 세션입니다: " + sessionId));
+        
+        Page<ChatMessage> messages = chatMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId, pageable);
+        
+        return messages.map(this::convertToMessageResponseDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ChatMessageResponseDto> getAllMessages(Integer sessionId) {
+        log.info("모든 메시지 조회 요청 - 세션 ID: {}", sessionId);
+        
+        // 세션 존재 확인
+        chatSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 세션입니다: " + sessionId));
+        
+        List<ChatMessage> messages = chatMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
+        
+        return messages.stream()
+                .map(this::convertToMessageResponseDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public int cleanupExpiredData(int expiredHours) {
+        log.info("만료된 데이터 정리 시작 - 만료 시간: {}시간", expiredHours);
+        
+        LocalDateTime expiredTime = LocalDateTime.now().minusHours(expiredHours);
+        
+        // 만료된 메시지 삭제
+        List<ChatMessage> expiredMessages = chatMessageRepository.findExpiredMessages(expiredTime);
+        chatMessageRepository.deleteAll(expiredMessages);
+        
+        // 만료된 세션 삭제
+        List<ChatSession> expiredSessions = chatSessionRepository.findExpiredSessions(expiredTime);
+        chatSessionRepository.deleteAll(expiredSessions);
+        
+        int totalCleaned = expiredMessages.size() + expiredSessions.size();
+        log.info("만료된 데이터 정리 완료 - 삭제된 항목 수: {}", totalCleaned);
+        
+        return totalCleaned;
+    }
+
+    @Override
+    public ChatMessageResponseDto generateAiResponse(Integer sessionId, String userMessage) {
+        log.info("AI 응답 생성 요청 - 세션 ID: {}, 사용자 메시지: {}", sessionId, userMessage);
+        
+        // 세션 조회
+        ChatSession session = chatSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 세션입니다: " + sessionId));
+        
+        // 샘플 데이터 기반 AI 응답 생성 (추후 실제 AI 로직으로 대체)
+        String aiResponse = generateSampleAiResponse(session, userMessage);
+        
+        // AI 응답 메시지 저장
+        ChatMessage aiMessage = ChatMessage.builder()
+                .session(session)
+                .senderType(MessageSenderType.AI)
+                .messageContent(aiResponse)
+                .messageType(MessageType.TEXT)
+                .metadata("{\"ai_generated\": true, \"response_time_ms\": 1500}")
+                .build();
+        
+        ChatMessage savedMessage = chatMessageRepository.save(aiMessage);
+        log.info("AI 응답 생성 완료 - 메시지 ID: {}", savedMessage.getId());
+        
+        return convertToMessageResponseDto(savedMessage);
+    }
+
+    /**
+     * 샘플 데이터 기반 AI 응답 생성 (MVP용)
+     * 추후 실제 AI 로직으로 대체 예정
+     */
+    private String generateSampleAiResponse(ChatSession session, String userMessage) {
+        return chatAiService.generateResponse(session, userMessage);
+    }
+
+    /**
+     * ChatSession을 ChatSessionResponseDto로 변환
+     */
+    private ChatSessionResponseDto convertToSessionResponseDto(ChatSession session) {
+        return ChatSessionResponseDto.builder()
+                .id(session.getId())
+                .userId(session.getUser().getId())
+                .userName(session.getUser().getUserName())
+                .sessionType(session.getSessionType())
+                .language(session.getLanguage())
+                .status(session.getStatus())
+                .sessionData(session.getSessionData())
+                .createdAt(session.getCreatedAt())
+                .updatedAt(session.getUpdatedAt())
+                .build();
+    }
+
+    /**
+     * ChatMessage를 ChatMessageResponseDto로 변환
+     */
+    private ChatMessageResponseDto convertToMessageResponseDto(ChatMessage message) {
+        return ChatMessageResponseDto.builder()
+                .id(message.getId())
+                .sessionId(message.getSession().getId())
+                .senderType(message.getSenderType())
+                .messageContent(message.getMessageContent())
+                .messageType(message.getMessageType())
+                .metadata(message.getMetadata())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
- Add ChatController with REST endpoints for sessions and messages
- Create ChatService interface and ChatServiceImpl implementation
- Implement ChatAiService for sample data-based AI responses
- Add DTOs for chat session and message operations
- Extend ProductRepository with product search functionality
- Support session management and message history retrieval