### PR TITLE
fix: Remove HS code foreign key constraint 

### DIFF
--- a/src/main/java/com/suracle/backend_api/entity/product/Product.java
+++ b/src/main/java/com/suracle/backend_api/entity/product/Product.java
@@ -54,7 +54,9 @@ public class Product extends BaseEntity {
   @Column(name = "is_active", nullable = false)
   private Boolean isActive;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "hs_code", referencedColumnName = "hs_code", insertable = false, updatable = false)
-  private HsCode hsCodeEntity;
+  // HS 코드 엔티티 매핑 제거 - 외래키 제약조건 없이 단순 문자열로 저장
+  // 필요시 별도 서비스에서 조회하도록 변경
+  // @ManyToOne(fetch = FetchType.LAZY)
+  // @JoinColumn(name = "hs_code", referencedColumnName = "hs_code", insertable = false, updatable = false)
+  // private HsCode hsCodeEntity;
 }


### PR DESCRIPTION
상품 등록 시 500 에러 해결을 위한 HS 코드 외래키 제약조건 제거

## 문제 상황
- 상품 등록 시 500 Internal Server Error 발생
- 원인: AI가 추천한 HS 코드가 hs_codes 테이블에 존재하지 않아 외래키 제약조건 위반
- 에러 메시지: "products" 테이블에서 "fkicibm6bd535i349msn9xx4ifw" 참조키 제약 조건 위배

## 🔧 해결 방안
**Before:**
```java
@ManyToOne(fetch = FetchType.LAZY)
@JoinColumn(name = "hs_code", referencedColumnName = "hs_code", insertable = false, updatable = false)
private HsCode hsCodeEntity;
```

**After:**
```java
// HS 코드 엔티티 매핑 제거 - 외래키 제약조건 없이 단순 문자열로 저장
// 필요시 별도 서비스에서 조회하도록 변경
// @ManyToOne(fetch = FetchType.LAZY)
// @JoinColumn(name = "hs_code", referencedColumnName = "hs_code", insertable = false, updatable = false)
// private HsCode hsCodeEntity;
```